### PR TITLE
Add print functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,6 +449,10 @@
                     <i class="fa-solid fa-save"></i>
                     <span class="tooltip">שמור (Ctrl+S)</span>
                 </button>
+                <button class="btn" id="print-btn" title="הדפס">
+                    <i class="fa-solid fa-print"></i>
+                    <span class="tooltip">הדפס (Ctrl+P)</span>
+                </button>
             </div>
         </div>
 
@@ -1383,6 +1387,143 @@ document.addEventListener('click', function() {
             // === SAVE DOCUMENT ===
             document.getElementById('save-btn').addEventListener('click', saveDocument);
 
+            // Print functionality
+            document.getElementById('print-btn').addEventListener('click', function() {
+                printDocument();
+            });
+
+            async function printDocument() {
+                const markdown = editor.getValue();
+                let html = marked.parse(markdown);
+                html = processMath(html);
+                const sanitizedHtml = DOMPurify.sanitize(html, {
+                    ADD_TAGS: ['math', 'mrow', 'mi', 'mo', 'mn', 'msup', 'msub', 'mfrac'],
+                    ADD_ATTR: ['display', 'dir', 'style']
+                });
+
+                const printWindow = window.open('', '_blank');
+                printWindow.document.write(`
+                    <!DOCTYPE html>
+                    <html lang="he" dir="rtl">
+                    <head>
+                        <meta charset="UTF-8">
+                        <title>הדפסת מסמך Markdown</title>
+                        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.8/katex.min.css">
+                        <style>
+                            * {
+                                box-sizing: border-box;
+                                margin: 0;
+                                padding: 0;
+                            }
+                            body {
+                                font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+                                line-height: 1.6;
+                                padding: 40px;
+                                max-width: 800px;
+                                margin: 0 auto;
+                                color: #000;
+                            }
+                            h1, h2, h3, h4, h5, h6 {
+                                margin-top: 1.5em;
+                                margin-bottom: 0.75em;
+                                font-weight: 600;
+                            }
+                            h1 {
+                                font-size: 2em;
+                                border-bottom: 1px solid #ccc;
+                                padding-bottom: 0.3em;
+                            }
+                            h2 {
+                                font-size: 1.5em;
+                                border-bottom: 1px solid #ccc;
+                                padding-bottom: 0.3em;
+                            }
+                            h3 { font-size: 1.25em; }
+                            p { margin-bottom: 1.25em; }
+                            a { color: #0070f3; }
+                            blockquote {
+                                border-right: 4px solid #0070f3;
+                                margin: 1.5em 0;
+                                padding: 0.8em 1.4em;
+                                background-color: #f7f9fc;
+                            }
+                            pre {
+                                background-color: #f7f9fc;
+                                padding: 1.2em;
+                                border-radius: 4px;
+                                overflow-x: auto;
+                                direction: ltr;
+                                text-align: left;
+                                font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+                                font-size: 14px;
+                            }
+                            code {
+                                font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+                                background-color: #f7f9fc;
+                                padding: 0.2em 0.4em;
+                                border-radius: 4px;
+                                font-size: 0.9em;
+                                direction: ltr;
+                            }
+                            pre code {
+                                background: none;
+                                padding: 0;
+                            }
+                            table {
+                                width: 100%;
+                                border-collapse: collapse;
+                                margin: 1.5em 0;
+                            }
+                            table th, table td {
+                                padding: 0.8em 1.2em;
+                                border: 1px solid #ccc;
+                                text-align: right;
+                            }
+                            table th {
+                                background-color: #f7f9fc;
+                                font-weight: 600;
+                            }
+                            table tr:nth-child(even) {
+                                background-color: #f7f9fc;
+                            }
+                            img {
+                                max-width: 100%;
+                                height: auto;
+                            }
+                            ul, ol {
+                                margin: 1.25em 1.5em 1.25em 0;
+                            }
+                            li {
+                                margin-bottom: 0.5em;
+                            }
+                            .katex-display {
+                                margin: 1.5em 0;
+                                overflow-x: auto;
+                                text-align: center;
+                            }
+                            @media print {
+                                body {
+                                    padding: 0;
+                                }
+                                pre {
+                                    white-space: pre-wrap;
+                                    word-wrap: break-word;
+                                }
+                            }
+                        </style>
+                    </head>
+                    <body>
+                        ${sanitizedHtml}
+                    </body>
+                    </html>
+                `);
+                printWindow.document.close();
+                printWindow.focus();
+                setTimeout(() => {
+                    printWindow.print();
+                }, 250);
+            }
+
             async function saveDocument() {
                 const content = editor.getValue();
 
@@ -1624,6 +1765,10 @@ document.addEventListener('click', function() {
                 if ((e.ctrlKey || e.metaKey) && e.key === 'o') {
                     e.preventDefault();
                     openDocument();
+                }
+                if ((e.ctrlKey || e.metaKey) && e.key === 'p') {
+                    e.preventDefault();
+                    printDocument();
                 }
             });
 

--- a/styles.css
+++ b/styles.css
@@ -1363,3 +1363,59 @@ button {
   left: 0;
   top: 0;
 }
+
+/* ===== PRINT STYLES ===== */
+@media print {
+  body {
+    background: white !important;
+    color: black !important;
+  }
+
+  .app-container,
+  .app-header,
+  .toolbar,
+  .status-bar,
+  .editor-panel,
+  .divider {
+    display: none !important;
+  }
+
+  .preview-panel {
+    display: block !important;
+    max-width: 100% !important;
+  }
+
+  .preview-content {
+    padding: 0 !important;
+    max-width: 100% !important;
+  }
+
+  .preview-content pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+  }
+
+  .preview-content a {
+    color: #000 !important;
+    text-decoration: underline !important;
+  }
+
+  .preview-content img {
+    max-width: 100% !important;
+    page-break-inside: avoid;
+  }
+
+  .preview-content h1,
+  .preview-content h2,
+  .preview-content h3,
+  .preview-content h4,
+  .preview-content h5,
+  .preview-content h6 {
+    page-break-after: avoid;
+  }
+
+  .preview-content pre,
+  .preview-content code {
+    page-break-inside: avoid;
+  }
+}


### PR DESCRIPTION
## Summary
- Add print button in toolbar with Hebrew tooltip (הדפס)
- Implement print function that renders markdown preview in new window
- Add Ctrl+P keyboard shortcut for printing
- Include KaTeX CSS for math formula rendering in print
- Add print media queries to styles.css for better printing when printing from preview mode

## Testing
- Tested locally by clicking print button and using Ctrl+P shortcut
- Print preview window opens with RTL Hebrew content
- Math formulas render correctly via KaTeX

Would love to contribute this feature to make the Hebrew Markdown editor more useful!